### PR TITLE
Update the Dockerfile to modernise requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,9 @@
-FROM node:15.7-alpine
+FROM node:18-alpine
 
 ENV NODE_ENV=production
 
 RUN addgroup -g 1017 -S appgroup \
-  && adduser -u 1017 -S appuser -G appgroup \
-  && apk update \
-  && apk add build-base python
+  && adduser -u 1017 -S appuser -G appgroup
 
 WORKDIR /app
 


### PR DESCRIPTION
Update the base image to Node 18 and remove
the install python step.  The current node
modules do not require Python on the base image

This has been buit and tested locally