### PR TITLE
Fix: Dependabot file location

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: weekly
       day: tuesday
-      time: "3:00"
+      time: "03:00"
       timezone: Europe/London
     groups:
       npm:


### PR DESCRIPTION
This got created too deep in the github folder and was not being picked correctly by github

It also updates the time to 00:00 format to allow it to be parsed 